### PR TITLE
ignore .vs/ and __pycache__/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+.vs/
+*__pycache__/


### PR DESCRIPTION
As I'm using VS code it would be great if `.vs/` was ignored by default.

Same goes for `__pycache__/` which often shows up at strange locations in the source tree.